### PR TITLE
Updated file to replace RHEL8 reference

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7466,7 +7466,7 @@
   blockinfile:
     path: /etc/audit/rules.d/30-ospp-v42-remediation.rules
     create: true
-    block: '## This content is a section of an Audit config snapshot recommended for RHEL8 sytems that target OSPP compliance.
+    block: '## This content is a section of an Audit config snapshot recommended for RHEL7 sytems that target OSPP compliance.
 
       ## The following content has been retreived on 2019-03-11 from: https://github.com/linux-audit/audit-userspace/blob/master/rules/30-ospp-v42.rules
 


### PR DESCRIPTION
The current file contains a reference to RHEL8, which appears in the comment section at the top of one of the audit files on the target system

This single char change corrects this to RHEL7